### PR TITLE
add NoColor flag as togglable

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,23 +19,24 @@ It gets the job done and I use it frequently to generate colorized output myself
 ```go
     // Initialite a colorify struct. Structs can be initialized either with only string attributes(bold/italics/reverse)
 	// Or also with color values set.
-	// Example --> Struct with no color set. 
-	noColStruct := colorify.Colorify{Attr: colorify.Underline}
-    // Example --> Struct with color preset.
+	// Example --> Struct with no color set. You can also set the NoColor flag to force color output or supress it. 
+	//Keeping it UnSet allows the library to determine if its a tty and output colored output in that case.
+	noColStruct := colorify.Colorify{Attr: colorify.Underline, NoColor: "false"}
+	// Example --> Struct with color preset.
 	withColStruct := colorify.Colorify{Color: colorify.Green, Attr: colorify.Bold}
 	// Supported attributes --> 
 	1. `colorify.Regular`: Regular text format.
 	2. `colorify.Italics`: Italicized text format.
 	3. `colorify.Transparent`: Transparent text format.
 	4. 	`colorify.Reverse`: Background reversed text format.
-    // Invoking the print functions after this is just as easy as calling the appropriate ones with particular arguments.
+	// Invoking the print functions after this is just as easy as calling the appropriate ones with particular arguments.
 	// Please note that the library has support column based coloring scheme, which means you can have as many colors in 
 	// one single line as you want.
 	io.WriteString(os.Stdout, noColStruct.Sprintln("This is regular", colorify.Green, "This is green!"))
 	noColStruct.Println(colorify.Red, "[Error]", colorify.Yellow, "This is a new error")
-    io.WriteString(os.Stdout, col.Sprintln("\n", colorify.Blue, "This", "is", "Sparta"))
-	// Example with color initialized in struct.
-    withColStruct.Println("Should be green and bold!")
+	io.WriteString(os.Stdout, col.Sprintln("\n", colorify.Blue, "This", "is", "Sparta"))
+	// Example with color initialized in struct. 
+	withColStruct.Println("Should be green and bold!")
 ```
 
 For more examples checkout the `examples/` directory.

--- a/colorify.go
+++ b/colorify.go
@@ -7,7 +7,10 @@ package colorify
 
 import (
 	"fmt"
+	tb "github.com/mainak90/trickB"
+	"github.com/mattn/go-isatty"
 	"io"
+	"os"
 )
 
 // Main struct for interfacing with all golang fmt functions.  Elems -->  1. Color --> The colored o/p choice.
@@ -16,7 +19,7 @@ import (
 type Colorify struct {
 	Color       Color
 	Attr        Attr
-	NoColor     bool
+	NoColor     string
 	ColorScheme string
 }
 
@@ -50,6 +53,18 @@ var (
 	Regular   		Attr  = "0;"
 )
 
+func doColor(c *Colorify) bool {
+	switch tb.TrickBFromString(c.NoColor) {
+	case tb.UnSet:
+		return isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd())
+	case tb.True:
+		return false
+	case tb.False:
+		return true
+	default:
+		return true
+	}
+}
 
 func stringifyColumnar(c *Colorify, inf ...interface{}) string {
 	var infString string
@@ -58,8 +73,12 @@ func stringifyColumnar(c *Colorify, inf ...interface{}) string {
 	for _, val := range inf {
 		switch val.(type) {
 		case Color:
-			colScheme := makeColorString(c, val.(Color))
-			infString += fmt.Sprintf("%s", colScheme)
+			if doColor(c) {
+				colScheme := makeColorString(c, val.(Color))
+				infString += fmt.Sprintf("%s", colScheme)
+			} else {
+				continue
+			}
 		case string:
 			infString += fmt.Sprintf("%s%s", " ", val)
 		default:

--- a/examples/main.go
+++ b/examples/main.go
@@ -10,7 +10,7 @@ import (
 func main() {
 	// Int the struct first, now this struct can be reused for all further interface invocations.
 	// In general as string attributes are seldom changed, you can initialize them directly at the struct level.
-	col := colorify.Colorify{Attr: colorify.Bold}
+	col := colorify.Colorify{Attr: colorify.Bold, NoColor: "false"}
 	colEmpty := colorify.Colorify{Attr: colorify.Regular}
 	// The color schemes are columnar, which now means you can use one color for out print output
 	//or as many colors as you like. Colors can be set directly on the interface function level making it easier.

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/mainak90/colorify
 
 go 1.16
+
+require (
+	github.com/mainak90/trickB v0.0.3
+	github.com/mattn/go-isatty v0.0.18
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/iancoleman/strcase v0.2.0 h1:05I4QRnGpI0m37iZQRuskXh+w77mr6Z41lwQzuHLwW0=
+github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
+github.com/mainak90/trickB v0.0.3 h1:tJrPnX97OjG832pEfrfgsx+kenFWSTbg90F5rX4S3h0=
+github.com/mainak90/trickB v0.0.3/go.mod h1:n/z+6MTbQvKYVt5YLidIR7hAJn5Fcr7jOmhR3PCNtiE=
+github.com/mattn/go-isatty v0.0.18 h1:DOKFKCQ7FNG2L1rbrmstDN4QVRdS89Nkh85u68Uwp98=
+github.com/mattn/go-isatty v0.0.18/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
1. `NoColor` flag changed to string.
2. Use my personal library `TrickB` to set/unset custom boolean flag.
3. The `colorify` main struct attribute `NoColor` can now be set explicitely by user.
4. Examples and readme updated.